### PR TITLE
readme: add license section

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ We would like to thank the original creators of the Alpaca datasets for making t
 
 # Licensing
 
-The Cleaned German Alpaca Dataset is licensed under [CC BY NC 4.0](DATA_LICENSE).
+The Cleaned German Alpaca Dataset is licensed under [CC BY NC 4.0](https://github.com/LEL-A/GerAlpacaDataCleaned/blob/main/DATA_LICENSE).
 
 The software and tools in this repository is licensed under the **MIT License** (the "License");
 you may not use this file except in compliance with the License. You may obtain a copy of the License by reviewing the file

--- a/README.md
+++ b/README.md
@@ -23,3 +23,11 @@ By removing errors and inconsistencies, the goal is to improve performance of th
 We would like to thank the authors of the Cleaned Alpaca dataset for their effort.
 
 We would like to thank the original creators of the Alpaca datasets for making their data available to the public.
+
+# Licensing
+
+The Cleaned German Alpaca Dataset is licensed under [CC BY NC 4.0](DATA_LICENSE).
+
+The software and tools in this repository is licensed under the **MIT License** (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy of the License by reviewing the file
+[LICENSE](https://github.com/LEL-A/GerAlpacaDataCleaned/blob/main/LICENSE) in the repository.


### PR DESCRIPTION
Hi,

this PR add a license section to main readme. We have two different licenses:

* MIT is used for all tools and software here
* CC BY NC 4.0 is used for the created Dataset (it matches original Alpaca license and Cleaned Alpaca dataset)